### PR TITLE
Do not load styles on non bontact setting pages

### DIFF
--- a/classes/class-bont-admin-ui.php
+++ b/classes/class-bont-admin-ui.php
@@ -10,7 +10,11 @@ class BONT_Admin_UI {
 			//$submenu['bontact-settings'][0][0] = __( 'General Settings', 'bontact' );
 	}
 	
-	public function admin_print_scripts() {
+	public function admin_print_scripts($hook) {
+		// Load only on ?page=bontact-settings
+        if($hook != 'bontact-settings') {
+			return;
+        }
 		wp_enqueue_style( 'bont-admin-ui', plugins_url( '/assets/css/admin-ui.min.css', BONTACT_BASE_FILE ) );
 		wp_enqueue_style( 'bont-admin-uia', plugins_url( '/assets/css/bootstrap.min.css', BONTACT_BASE_FILE ) );
 		wp_enqueue_style( 'bont-admin-uib', plugins_url( '/assets/css/login.css', BONTACT_BASE_FILE ) );


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/bontact-breaks-woocommerce-back-end/ and https://wordpress.org/support/topic/product-data-tabs-not-working/#post-8538488